### PR TITLE
Add basic testing for all pushes and pull requests

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,31 @@
+# Modified from Python package. Installs package in multiple environments and runs tests.
+
+name: Python install and test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7","3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        python -m pip install .
+    - name: Test with pytest
+      run: |
+        pytest tests

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,10 +4,10 @@ name: Python install and test
 
 on:
   push:
-    - branches
+    branches:
       - main
   pull_request:
-    - branches
+    branches:
       - main
 
 jobs:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,7 +4,11 @@ name: Python install and test
 
 on:
   push:
+    - branches
+      - main
   pull_request:
+    - branches
+      - main
 
 jobs:
   build:
@@ -21,7 +25,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest


### PR DESCRIPTION
I tried setting up a very basic GitHub Actions workflow to install the package and run Pytest in our target Python version (3.7-3.10) on all pushes and pull requests. Runs successfully and as expected from the actions panel.

This may eliminate the need for tox, unless we want to keep that for testing on local platforms.