### PR TITLE
Add license and binder badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # GDMATE - GeoDynamic Modeling Analysis Toolkit and Education
+[![License: GPL v2](https://img.shields.io/badge/License-GPL_v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdmate/gdmate/HEAD)
 
 ## About
 


### PR DESCRIPTION
This adds a GPL 2 license badge and a binder badge to the README. The binder badge will load a Jupyter Hub environment that installs the package using the setup.py file. Note that the badge always points to the main branch on gdmate/gdmate, not to development branches. Making the binder environment easy to use is also another reason to come up with a way to get the notebooks out of the docs directory, since right now getting to the notebooks within binder requires navigating through docs.