### PR TITLE
Addded notebook testing to GitHub workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,8 +32,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install wheel
-        python -m pip install pytest
+        python -m pip install pytest nbmake
         python -m pip install .
     - name: Test with pytest
       run: |
-        pytest tests
+        pytest --nbmake


### PR DESCRIPTION
This modifies the GitHub actions workflow to use the `nbmake` plugin for `pytest`, which will now include testing that all Jupyter Notebooks execute successfully during the standard testing checks.