### PR TITLE
Add flow law module

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,3 +5,4 @@ API
     :toctree: generated
 
     gdmate.helloworld
+    gdmate.flow_laws

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to gdmate's documentation!
 
    api
    notebooks/helloworld
+   notebooks/flow_laws
 
 
 

--- a/gdmate/__init__.py
+++ b/gdmate/__init__.py
@@ -1,1 +1,2 @@
 from gdmate.helloworld import helloworld
+from gdmate.material_models import flow_laws

--- a/gdmate/material_models/flow_laws.py
+++ b/gdmate/material_models/flow_laws.py
@@ -1,0 +1,201 @@
+"""
+Module for flow law calculations
+"""
+import numpy as np
+
+def get_published(material,source,creep,dryness):
+    """
+    Get published values for flow law.
+
+    Parameters:
+        material: rock/mineral being deformed
+        source: first author of original source
+        creep: dislocation or diffusion creep
+        dryness: wet or dry
+
+    Returns:
+        A: prefactor (MPa^-n-r um^m_diff s^-1)
+        n: stress exponent
+        m_diff: grain size exponent
+        r: fugacity exponent
+        E: activation energy (kJ/mol)
+        V: activation volume (10^-6 m^3/mol)
+    """
+    # Combine properties into a tuple
+    props = (material,source,creep,dryness)
+
+    # Get values depending on tuple supplied
+    if props == ('olivine','hirth','dislocation','dry'):
+        A = 1.1e5 # MPa^-n-r um^m_diff s^-1
+        n = 3.5
+        m_diff = 0
+        r = 0
+        E = 530 # kJ/mol
+
+        # V taken from Table 2 but is variable
+        V = 18 # 10^-6 m^3/mol
+
+    elif props == ('olivine','hirth','dislocation','wet'):
+        # Used values for constant COH of 1000 H/10^6Si
+        A = 90 # MPa^-n-r um^m_diff s^-1
+        n = 3.5
+        m_diff = 0
+        r = 1.2
+        E = 480 # kJ/mol
+        V = 11 # 10^-6 m^3/mol
+
+    elif props == ('olivine','hirth','diffusion','dry'):
+        A = 1.5e9 # MPa^-n-r um^m_diff s^-1
+        n = 1
+        m_diff = 3
+        r = 0
+        E = 375 #kJ/mol
+
+        # Lower end of a range from 2-10
+        V = 2 # 10^-6 m^3/mol
+
+    elif props == ('olivine','hirth','diffusion','wet'):
+        # Used values for constant COH of 1000 H/10^6Si
+        A = 1.0e6 # MPa^-n-r um^m_diff s^-1
+        n = 1
+        m_diff = 3
+        r = 1
+        E = 335 # kJ/mol
+        V = 4 # 10^-6 m^3/mol
+
+    elif props == ('quartzite','gleason','dislocation','wet'):
+        # Water fugacity not included in units so not used for conversion
+        A = 1.1e-4 # MPa^-n s^-1 um^m_diff s^-1
+        n = 4
+        m_diff = 0
+        r = 0 # Not considered
+        E = 223 # kJ/mol
+        V = 0 # 10^-6 m^3/mol
+    
+    elif props == ('anorthite','rybacki','dislocation','wet'):
+        # A reported as log(A) so converted to A here
+        A = 10**0.2 # MPa^-n-r um^m_diff s^-1
+        n = 3
+        m_diff = 0
+        r = 1
+        E = 345 # kJ/mol
+        V = 38 # 10^-6 m^3/mol
+    
+    return(A,n,m_diff,r,E,V)
+        
+def convert2SI(values):
+    """
+    Convert published flow law values to SI units.
+    
+    Assumes units follow those in Hirth and Kohlstedt, 2003.
+    Only changes A, E, and V.
+
+    Parameters:
+        values: tuple of published values (A,n,m_diff,r,E,V)
+    
+    Return:
+        values_SI: tuple of values with A,E, and V in SI units 
+                    (A_SI,n,m_diff,r,E_SI,V_SI)
+    """
+
+    # Unpack tuple
+    A_pub = values[0]
+    n = values[1]
+    m_diff = values[2]
+    r = values[3]
+    E_pub = values[4]
+    V_pub = values[5]
+
+    # Apply unit conversions
+    A_SI = A_pub * 1e6**(-n-r) * 1e-6**(m_diff) # s^-1 Pa^-n-r m^m_diff
+    E_SI = E_pub * 1000 # J/mol
+    V_SI = V_pub * 1e-6 # m^3/mol
+
+    # Repack tuple
+    values_SI = (A_SI,n,m_diff,r,E_SI,V_SI)
+
+    return(values_SI)
+
+def scaleA(A_SI,n):
+    """
+    Scale A from uniaxial experiments for ASPECT.
+
+    Implemented in Dannberg et al., 2017 supplementary Excel file. Appropriate
+    for relating strain rate to viscosity for a uniaxial strain experiment.
+
+    Parameters:
+        A_SI: prefactor in SI units (MPa^-n-r um^m_diff s^-1)
+        n: stress exponent
+    
+    Returns:
+        A_scaled: Scaled A in SI units (MPa^-n-r um^m_diff s^-1)
+    """
+    A_scaled = 2**(n-1) * 3**((n+1)/2) * A_SI
+
+    return(A_scaled)
+
+def get_flow_law_parameters(material,source,creep,dryness):
+    """
+    Get flow law parameters in correct units and scaled for ASPECT
+
+    Converts published values to SI units and then scales the prefactor (A).
+    Prints the values at each step and returns the final values for use in 
+    ASPECT.
+
+    Parameters:
+        material: rock/mineral being deformed
+        source: first author of original source
+        creep: dislocation or diffusion creep
+        dryness: wet or dry
+
+    Returns:
+        A_scaled: scaled prefactor (Pa^-n-r m^m_diff s^-1)
+        n: stress exponent
+        m_diff: grain size exponent
+        r: fugacity exponent
+        E_SI: activation energy (J/mol)
+        V_SI: activation volume (m^3/mol)
+    """
+
+    # Get the published values
+    values = get_published(material,source,creep,dryness)
+
+    # Format to 2 decimal places and print.
+    values_str = ['{:0.2e}'.format(x) for x in values]
+
+    print('Published Values:')
+    print('A - prefactor (MPa^-n-r um^m_diff s^-1): ',values_str[0])
+    print('n - stress exponent: ',values_str[1])
+    print('m_diff - grain size exponent: ',values_str[2])
+    print('r - fugacity exponent: ',values_str[3])
+    print('E - activation energy (kJ/mol)',values_str[4])
+    print('V - activation volume (10^-6 m^3/mol)',values_str[5])
+
+    # Convert values to SI units
+    converted = convert2SI(values)
+
+    # Format to 2 decimal places and print.
+    converted_str = ['{:0.2e}'.format(x) for x in converted]
+
+    print('\nConverted to SI Units:')
+    print('A (Pa^-n-r m^m_diff s^-1): ',converted_str[0])
+    print('E - activation energy (J/mol): ',converted_str[4])
+    print('V - activation volume (m^3/mol): ',converted_str[5])
+
+    # Scale the A prefactor
+    A_scaled = scaleA(converted[0],converted[1])
+
+    # Format to 2 decimal places and print.
+    A_scaled_str = '{:0.2e}'.format(A_scaled)
+
+    print('\nScaled A for ASPECT:')
+    print('A scaled (Pa^-n-r m^m_diff s^-1): ',A_scaled_str)
+
+    # Pull values from appropriate tuple for output.
+    n = values[1]
+    m = values[2]
+    r = values[3]
+    E_SI = converted[4]
+    V_SI = converted[5]
+
+    return(A_scaled,n,m,r,E_SI,V_SI)

--- a/notebooks/flow_laws.ipynb
+++ b/notebooks/flow_laws.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Viscous Flow Law Unit Conversions and Scaling for ASPECT #\n",
+    "This notebook demonstrates the use of the gdmate.flow module for obtaining the correct viscous flow law values for use in ASPECT. There are two key considerations: unit conversions and scaling of the prefactor term"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import GDMATE\n",
+    "import gdmate as gd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a quick calculation/explanation of the flow laws, the function `gd.flow.get_flow_law_parameters` will do the appropriate conversion/scaling for the given flow law. The flow law is defined in this function by a set of 4 inputs corresponding to the material, source, type of creep, and dryness. Current options are:\n",
+    "\n",
+    "_Olivine - Hirth and Kohlstedt, 2003_\n",
+    "* dry dislocation\n",
+    "* wet dislocation\n",
+    "* dry diffusion\n",
+    "* wet diffusion\n",
+    "\n",
+    "_Quartzite - Gleason and Tullis, 1995_\n",
+    "* wet dislocation\n",
+    "\n",
+    "_Anorthite - Rybacki et al., 2006_\n",
+    "* wet dislocation\n",
+    "\n",
+    "The output of this function is a tuple with the scaled/converted values in the form `(A_scaled,n,m_diff,r,E_converted,V_converted)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Published Values:\n",
+      "A - prefactor (MPa^-n-r um^m_diff s^-1):  1.10e+05\n",
+      "n - stress exponent:  3.50e+00\n",
+      "m_diff - grain size exponent:  0.00e+00\n",
+      "r - fugacity exponent:  0.00e+00\n",
+      "E - activation energy (kJ/mol) 5.30e+02\n",
+      "V - activation volume (10^-6 m^3/mol) 1.80e+01\n",
+      "\n",
+      "Converted to SI Units:\n",
+      "A (Pa^-n-r m^m_diff s^-1):  1.10e-16\n",
+      "E - activation energy (J/mol):  5.30e+05\n",
+      "V - activation volume (m^3/mol):  1.80e-05\n",
+      "\n",
+      "Scaled A for ASPECT:\n",
+      "A scaled (Pa^-n-r m^m_diff s^-1):  7.37e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "ol_hirth_dry_dislocation = gd.flow.get_flow_law_parameters(\n",
+    "    'olivine','hirth','dislocation','dry')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Published Values:\n",
+      "A - prefactor (MPa^-n-r um^m_diff s^-1):  9.00e+01\n",
+      "n - stress exponent:  3.50e+00\n",
+      "m_diff - grain size exponent:  0.00e+00\n",
+      "r - fugacity exponent:  1.20e+00\n",
+      "E - activation energy (kJ/mol) 4.80e+02\n",
+      "V - activation volume (10^-6 m^3/mol) 1.10e+01\n",
+      "\n",
+      "Converted to SI Units:\n",
+      "A (Pa^-n-r m^m_diff s^-1):  5.68e-27\n",
+      "E - activation energy (J/mol):  4.80e+05\n",
+      "V - activation volume (m^3/mol):  1.10e-05\n",
+      "\n",
+      "Scaled A for ASPECT:\n",
+      "A scaled (Pa^-n-r m^m_diff s^-1):  3.80e-25\n"
+     ]
+    }
+   ],
+   "source": [
+    "ol_hirth_wet_dislocation = gd.flow.get_flow_law_parameters(\n",
+    "    'olivine','hirth','dislocation','wet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Published Values:\n",
+      "A - prefactor (MPa^-n-r um^m_diff s^-1):  1.50e+09\n",
+      "n - stress exponent:  1.00e+00\n",
+      "m_diff - grain size exponent:  3.00e+00\n",
+      "r - fugacity exponent:  0.00e+00\n",
+      "E - activation energy (kJ/mol) 3.75e+02\n",
+      "V - activation volume (10^-6 m^3/mol) 2.00e+00\n",
+      "\n",
+      "Converted to SI Units:\n",
+      "A (Pa^-n-r m^m_diff s^-1):  1.50e-15\n",
+      "E - activation energy (J/mol):  3.75e+05\n",
+      "V - activation volume (m^3/mol):  2.00e-06\n",
+      "\n",
+      "Scaled A for ASPECT:\n",
+      "A scaled (Pa^-n-r m^m_diff s^-1):  4.50e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "ol_hirth_dry_diffusion = gd.flow.get_flow_law_parameters(\n",
+    "    'olivine','hirth','diffusion','dry')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Published Values:\n",
+      "A - prefactor (MPa^-n-r um^m_diff s^-1):  1.00e+06\n",
+      "n - stress exponent:  1.00e+00\n",
+      "m_diff - grain size exponent:  3.00e+00\n",
+      "r - fugacity exponent:  1.00e+00\n",
+      "E - activation energy (kJ/mol) 3.35e+02\n",
+      "V - activation volume (10^-6 m^3/mol) 4.00e+00\n",
+      "\n",
+      "Converted to SI Units:\n",
+      "A (Pa^-n-r m^m_diff s^-1):  1.00e-24\n",
+      "E - activation energy (J/mol):  3.35e+05\n",
+      "V - activation volume (m^3/mol):  4.00e-06\n",
+      "\n",
+      "Scaled A for ASPECT:\n",
+      "A scaled (Pa^-n-r m^m_diff s^-1):  3.00e-24\n"
+     ]
+    }
+   ],
+   "source": [
+    "ol_hirth_wet_diffusion = gd.flow.get_flow_law_parameters(\n",
+    "    'olivine','hirth','diffusion','wet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Published Values:\n",
+      "A - prefactor (MPa^-n-r um^m_diff s^-1):  1.58e+00\n",
+      "n - stress exponent:  3.00e+00\n",
+      "m_diff - grain size exponent:  0.00e+00\n",
+      "r - fugacity exponent:  1.00e+00\n",
+      "E - activation energy (kJ/mol) 3.45e+02\n",
+      "V - activation volume (10^-6 m^3/mol) 3.80e+01\n",
+      "\n",
+      "Converted to SI Units:\n",
+      "A (Pa^-n-r m^m_diff s^-1):  1.58e-24\n",
+      "E - activation energy (J/mol):  3.45e+05\n",
+      "V - activation volume (m^3/mol):  3.80e-05\n",
+      "\n",
+      "Scaled A for ASPECT:\n",
+      "A scaled (Pa^-n-r m^m_diff s^-1):  5.71e-23\n"
+     ]
+    }
+   ],
+   "source": [
+    "an_rybacki_wet_dislocation = gd.flow.get_flow_law_parameters(\n",
+    "    'anorthite','rybacki','dislocation','wet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Published Values:\n",
+      "A - prefactor (MPa^-n-r um^m_diff s^-1):  1.10e-04\n",
+      "n - stress exponent:  4.00e+00\n",
+      "m_diff - grain size exponent:  0.00e+00\n",
+      "r - fugacity exponent:  0.00e+00\n",
+      "E - activation energy (kJ/mol) 2.23e+02\n",
+      "V - activation volume (10^-6 m^3/mol) 0.00e+00\n",
+      "\n",
+      "Converted to SI Units:\n",
+      "A (Pa^-n-r m^m_diff s^-1):  1.10e-28\n",
+      "E - activation energy (J/mol):  2.23e+05\n",
+      "V - activation volume (m^3/mol):  0.00e+00\n",
+      "\n",
+      "Scaled A for ASPECT:\n",
+      "A scaled (Pa^-n-r m^m_diff s^-1):  1.37e-26\n"
+     ]
+    }
+   ],
+   "source": [
+    "qz_gleason_wet_dislocation = gd.flow.get_flow_law_parameters(\n",
+    "    'quartzite','gleason','dislocation','wet')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The code is also designed so that the individual steps can be examined and done discretely. The first step in most cases is converting A, E, and V to the correct SI units from the units in which they are typically reported in papers.\n",
+    "\n",
+    "### Converting to SI Units ###\n",
+    "\n",
+    "__A (prefactor)__\n",
+    "* Typically reported in $MPa^{(-n-r)} \\mu m^{m_{diff}} s^{-1}$\n",
+    "* Correct SI units are $Pa^{(-n-r)} m^{m_{diff}} s^{-1}$\n",
+    "* This requires the following conversion in most cases: <br>\n",
+    "$ A_{SI} = A_{published} \\cdot (10^{6})^{(-n-r)} \\cdot (10^{-6})^{m_{diff}}$ <br><br>\n",
+    "\n",
+    "\n",
+    "__E (activation energy)__\n",
+    "* Typically reported in $kJ/mol$, so just needs simple conversion to $J/mol$: <br>\n",
+    "$ E_{SI} = E_{published} \\cdot 1000$ <br><br>\n",
+    "\n",
+    "__V (activation volume)__\n",
+    "* Typically reported in $10^{-6} m^{3}/mol$, so just need to get the $10^{-6}$ into the value: <br>\n",
+    "$ V_{SI} = V_{published} \\cdot 10^{-6}$ <br><br>\n",
+    "\n",
+    "This conversion is implemented as a step in the function `convert2SI` and the published values can be accessed using `get_published`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(110000.0, 3.5, 0, 0, 530, 18)\n",
+      "(1.0999999999999999e-16, 3.5, 0, 0, 530000, 1.8e-05)\n"
+     ]
+    }
+   ],
+   "source": [
+    "ol_hirth_dry_dislocation_pub = gd.flow.get_published(\n",
+    "    'olivine','hirth','dislocation','dry')\n",
+    "\n",
+    "print(ol_hirth_dry_dislocation_pub)\n",
+    "\n",
+    "converted = gd.flow.convert2SI(ol_hirth_dry_dislocation_pub)\n",
+    "\n",
+    "print(converted)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scaling the Prefactor ###\n",
+    "Because published values are typically derived from uniaxial strain experiments, an additional scaling of the prefactor A is needed for input into ASPECT. ASPECT relates strain rate to viscosity using the following equation: <br><br>\n",
+    "\n",
+    "$ v = \\frac{1}{2} A^{-\\frac{1}{n}} d^{\\frac{m}{n}} \\dot{\\epsilon}_{ii}^{\\frac{(1-n)}{n}} exp (\\frac{E+PV}{nRT})$\n",
+    "\n",
+    "For this relationship, the correct scaling for A is: <br><br>\n",
+    "\n",
+    "$ A_{scaled} = 2^{(n-1)} \\cdot 3^{\\frac{(n+1)}{2}} \\cdot A_{SI} $\n",
+    "\n",
+    "This is implemented in the supplementary Excel file of Danneburg et al., 2017. In gdmate, the relevant function is `scaleA`.\n",
+    "\n",
+    "Note that this differs slightly from the scaling factor as written in the Gerya textbook - this is because Gerya's factor is not used to scale A; it is used to scale the viscosity (i.e., the entire equation above where $A^{-\\frac{1}{n}}$ is a factor). Since we only input A into ASPECT and not a factor by which to multiply the viscosity, we need to adjust the scaling factor accordingly to achieve the same viscosity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7.370390484088628e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Extract n from converted to SI output\n",
+    "A_SI = converted[0]\n",
+    "n = converted[1]\n",
+    "\n",
+    "scaled = gd.flow.scaleA(A_SI,n)\n",
+    "\n",
+    "print(scaled)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.5 ('test-gdmate')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "3a0988b725239a073417bba138430d121f840a6dc80affb76b70c3bf10777959"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     keywords="geodynamics",
-    packages=["gdmate"],
+    packages=["gdmate","gdmate.material_models"],
     python_requires=">=3.7, <4",
     install_requires=["numpy","scipy","matplotlib"],
     # package_data={ 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,0 +1,142 @@
+"""
+Tests for flow_laws module
+"""
+from pytest import approx
+from gdmate.material_models import flow_laws
+
+import numpy as np
+
+def test_get_published():
+    """Test get_published function"""
+
+    # Check that function returns expected values for each flow law
+    ol_dry_dis_hirth = flow_laws.get_published(
+        'olivine','hirth','dislocation','dry')
+    
+    assert ol_dry_dis_hirth == (1.1e5,3.5,0,0,530,18)
+
+    ol_wet_dis_hirth = flow_laws.get_published(
+        'olivine','hirth','dislocation','wet')
+
+    assert ol_wet_dis_hirth == (90,3.5,0,1.2,480,11)
+
+    ol_dry_dif_hirth = flow_laws.get_published(
+        'olivine','hirth','diffusion','dry')
+
+    assert ol_dry_dif_hirth == (1.5e9,1,3,0,375,2)
+
+    ol_wet_dif_hirth = flow_laws.get_published(
+        'olivine','hirth','diffusion','wet')
+
+    assert ol_wet_dif_hirth == (1.0e6,1,3,1,335,4)
+
+    qz_wet_dis_gleason = flow_laws.get_published(
+        'quartzite','gleason','dislocation','wet')
+
+    assert qz_wet_dis_gleason == (1.1e-4,4,0,0,223,0)
+
+    an_wet_dis_rybacki = flow_laws.get_published(
+        'anorthite','rybacki','dislocation','wet')
+
+    assert an_wet_dis_rybacki == (10**0.2,3,0,1,345,38)
+
+def test_convert2SI():
+    """Test convert2SI function"""
+    
+    # Set tolerances for approx function so value needs to be within 1% of the
+    # correct value
+    rel = 1e-2
+    abs = 1e-30
+
+    # Get published values and check conversions return correct values for
+    # each flow law.
+    ol_dry_dis_hirth = flow_laws.get_published(
+        'olivine','hirth','dislocation','dry')
+    
+    converted = flow_laws.convert2SI(ol_dry_dis_hirth)
+
+    assert converted == approx((1.10e-16,3.5,0,0,530e3,18e-6),
+    rel=rel,abs=abs)
+
+    ol_wet_dis_hirth = flow_laws.get_published(
+        'olivine','hirth','dislocation','wet')
+    
+    converted = flow_laws.convert2SI(ol_wet_dis_hirth)
+
+    assert converted == approx((5.68e-27,3.5,0,1.2,480e3,11e-6),
+    rel=rel,abs=abs)
+
+    ol_dry_dif_hirth = flow_laws.get_published(
+        'olivine','hirth','diffusion','dry')
+    
+    converted = flow_laws.convert2SI(ol_dry_dif_hirth)
+
+    assert converted == approx((1.50e-15,1,3,0,375e3,2e-6),
+    rel=rel,abs=abs)
+
+    ol_wet_dif_hirth = flow_laws.get_published(
+        'olivine','hirth','diffusion','wet')
+    
+    converted = flow_laws.convert2SI(ol_wet_dif_hirth)
+
+    assert converted == approx((1.00e-24,1,3,1,335e3,4e-6),
+    rel=rel,abs=abs)
+
+    qz_wet_dis_gleason = flow_laws.get_published(
+        'quartzite','gleason','dislocation','wet')
+
+    converted = flow_laws.convert2SI(qz_wet_dis_gleason)
+
+    assert converted == approx((1.10e-28,4,0,0,223e3,0),
+    rel=rel,abs=abs)
+
+    an_wet_dis_rybacki = flow_laws.get_published(
+        'anorthite','rybacki','dislocation','wet')
+
+    converted = flow_laws.convert2SI(an_wet_dis_rybacki)
+
+    assert converted == approx((1.58e-24,3,0,1,345e3,38e-6),
+     rel=rel,abs=abs)
+
+def test_scaleA():
+    """ Test for scaleA function"""
+
+    # Get published values for each flow law
+    ol_dry_dis_hirth = flow_laws.get_published(
+        'olivine','hirth','dislocation','dry')
+
+    ol_wet_dis_hirth = flow_laws.get_published(
+        'olivine','hirth','dislocation','wet')
+
+    ol_dry_dif_hirth = flow_laws.get_published(
+        'olivine','hirth','diffusion','dry')
+
+    ol_wet_dif_hirth = flow_laws.get_published(
+        'olivine','hirth','diffusion','wet')
+
+    qz_wet_dis_gleason = flow_laws.get_published(
+        'quartzite','gleason','dislocation','wet')
+
+    an_wet_dis_rybacki = flow_laws.get_published(
+        'anorthite','rybacki','dislocation','wet')  
+    
+    # Make list of published values
+    params = [ol_dry_dis_hirth,ol_wet_dis_hirth,
+    ol_dry_dif_hirth,ol_wet_dif_hirth,qz_wet_dis_gleason,
+    an_wet_dis_rybacki]
+
+    # Make list of correct scaled prefactors
+    answers = [7.37e-15,3.80e-25,4.50e-15,3.00e-24,
+                1.37e-26,5.71e-23]
+
+    # Loop through each set of published values, convert to SI units and scale
+    # A, then verify correct answer is obtained.
+    for k,law in enumerate(params):
+        converted = flow_laws.convert2SI(law)
+
+        A_SI = converted[0]
+        n = converted[1]
+
+        scaled = flow_laws.scaleA(A_SI,n)
+
+        assert scaled == approx(answers[k],rel=1e-2,abs=1e-30)


### PR DESCRIPTION
This adds a module `gdmate.material_models.flow_laws` that will obtain and convert/scale the appropriate values for viscous flow laws for input into ASPECT. In also includes a Jupyter Notebook to demonstrate the functionality and tests.

This PR will likely need to be edited depending on how #21 is merged and should probably not be merged until that is complete and potential conflicts are resolved.