### PR TITLE
Set up Sphinx API for recursive function page generation.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,7 +40,9 @@ To add the information from the docstring to the Sphinx documentation for GDMATE
 
 ```
 .. autosummary::
-    :toctree: generated
+    :toctree: generated 
+    :template: module.rst
+    :recursive:
 
     gdmate.module1
     gdmate.module2

--- a/docs/_templates/base.rst
+++ b/docs/_templates/base.rst
@@ -1,0 +1,3 @@
+{{ fullname | escape | underline}}
+
+.. auto{{ objtype }}:: {{ fullname }}

--- a/docs/_templates/module.rst
+++ b/docs/_templates/module.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+      :template: base.rst
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: module.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,17 @@
 API
 ***
+**Functions**
 
 .. autosummary::
     :toctree: generated
 
     gdmate.helloworld
+
+**Modules**
+
+.. autosummary::
+    :toctree: generated 
+    :template: module.rst
+    :recursive:
+
     gdmate.pyvista_vis

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,8 @@ extensions = [
     "myst_parser"
 ]
 
+autosummary_imported_members = True
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
This modifies the API Sphinx documentation so that a separate detailed page will be created for each function within a module. This required some modification of the default templates Sphinx generally uses for autogenerating API documentation.

Development version of the resulting Read the Docs API page can be seen here: https://gdmate-dvdev.readthedocs.io/en/latest/api.html

Addresses #28 